### PR TITLE
updated fs-extra

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/overlookmotel/fs-extra-promise/issues"
   },
   "dependencies": {
-    "fs-extra": "^0.24.0",
+    "fs-extra": "^0.26.0",
     "bluebird": "^2.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`fs-extra@0.26.2` has a bug fix so `outputJson` will be formatted again.
